### PR TITLE
Suppress output of 'which' command when it fails

### DIFF
--- a/modules/system.zsh
+++ b/modules/system.zsh
@@ -23,7 +23,7 @@ alien_ssh_client(){
 alien_battery_stat(){
   __os=`uname`;
   if [[ $__os = "Linux" ]]; then
-    if which upower > /dev/null ; then
+    if which upower > /dev/null 2>&1 ; then
       __bat_power=`upower -i /org/freedesktop/UPower/devices/battery_BAT0 | grep state | awk '{print $2}'`;
       __bat_power_ind="";
       if [[ $__bat_power = "charging" ]]; then __bat_power_ind="+";


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Docs have been added / updated in README.md (for features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a bug observed with the `which` command that is used to detect whether commands exist. It is used with the battery status command `upower`, but that doesn't necessarily exist on all machines. In that case, `which upower` might write an error message into stderr, which is currently not piped into /dev/null, i.e. it writes the error message to the screen, whenever the prompt is udpated. 


* **What is the current behavior?** (You can also link to an open issue here)
`which upower` writes an error message into stderr, which is then printed on the screen, if the upower command is not installed. This was observed on SL6 virtual machines (see attached screenshot).


* **What is the new behavior (if this is a feature change)?**
Pipe both stderr and stdout into /dev/null to completely suppress output of the `which` command. This fails silently on machines without the upower command and doesn't produce any output.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their configuration due to this PR?)
No breaking change expected.


* **Other information**:

![screen shot 2018-03-14 at 17 55 02](https://user-images.githubusercontent.com/10872677/37418470-968a3b62-27b2-11e8-823d-46222a570ad1.png)
