### PR TITLE
refactor prompt-creation-code, make modules more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,72 @@ Then activate the theme using:
 export ALIEN_CUSTOM_THEME_PATH=/path/to/custom/theme.zsh
 ```
 
-###### date format
+##### exit-code section
+
+To disable the numeric exit-code:
+
+```bash
+export ALIEN_SHOW_EXIT_CODE=0
+```
+
+##### date/time section
+
+To disable the date/time section:
+
+```bash
+export ALIEN_SHOW_DATE_TIME=0
+```
+
+To change the format of the date/time section:
 
 ```bash
 export ALIEN_DATE_TIME_FORMAT=%H:%M:%S # default is %r
+```
+
+##### battery section
+
+To disable the battery section:
+
+```bash
+export ALIEN_SHOW_BATTERY=0
+```
+
+##### user/host section
+
+To disable the user/host section:
+
+```bash
+export ALIEN_SHOW_USER_HOST=0
+```
+
+To not include the hostname:
+
+```bash
+export ALIEN_SHOW_HOST=0
+```
+
+##### path section
+
+To disable showing the full path:
+
+```bash
+export ALIEN_LONG_PATH=0
+```
+
+###### prompt symbol
+
+To change the symbol of the input-prompt:
+
+```bash
+export ALIEN_PROMPT_SYM=
+```
+
+###### section seperator
+
+To change the section-separator:
+
+```bash
+export ALIEN_SECTION_SEP_SYM=
 ```
 
 ###### Keep previous PROMPT:

--- a/alien.zsh
+++ b/alien.zsh
@@ -9,6 +9,7 @@ source "${THEME_ROOT}/libs/zsh-async/async.zsh"
 source "${THEME_ROOT}/libs/zsh-256color/zsh-256color.plugin.zsh"
 
 source "${THEME_ROOT}/modules/theme.zsh"
+source "${THEME_ROOT}/modules/prompt.zsh"
 source "${THEME_ROOT}/modules/system.zsh"
 source "${THEME_ROOT}/modules/git.zsh"
 source "${THEME_ROOT}/modules/hg.zsh"
@@ -22,15 +23,10 @@ function precmd(){
   alien_load_theme
 
   RPROMPT=''
-  if [[ "${DEFAULT_USER}" == "${USER}" ]]; then
-    _user=''
-  else
-    _user=`whoami`
-  fi
   if [[ ${PROMPT} == "" ]] || [[ ${ALIEN_KEEP_PROMPT} != 1 ]]; then
-    PROMPT="
-%(?.%K{$color0}%F{$color1}%f%k.%K{$color0}%F{$color1r}%f%k)%K{$color0}%F{$color2} $(alien_date_time_info)$(alien_battery_stat) %f%k%K{$color3}%F{$color0}%f%k%K{$color3}%F{$color4} $_user %f%k%K{$color5}%F{$color3}%f%k%K{$color5}%F{$color6} %~ %f%k%F{$color5}%f
-%F{$color3}$(alien_ssh_client)%f%F{$color14}`alien_venv`%f%F{$color8}%B❱%b%f "
+    alien_prompt_start
+    alien_prompt_end
+    PROMPT=$(alien_prompt_render)
   fi
   alien_async_prompt
 }

--- a/modules/async.zsh
+++ b/modules/async.zsh
@@ -3,23 +3,18 @@
 function alien_dummy(){}
 
 function alien_lprompt_complete() {
+  alien_prompt_start
   if [[ $(alien_is_git) == 1 ]]; then
-    PROMPT="
-%(?.%K{$color0}%F{$color1}%f%k.%K{$color0}%F{$color1r}%f%k)%K{$color0}%F{$color2} $(alien_date_time_info)$(alien_battery_stat) %f%k%K{$color3}%F{$color0}%f%k%K{$color3}%F{$color4} $_user %f%k%K{$color5}%F{$color3}%f%k%K{$color5}%F{$color6} %1~ %f%k%F{$color5}%K{$color7}%k%f%K{$color7}%F{$color9}`alien_git_branch`%f%k%K{$color10}%F{$color7}%f%k%K{$color10}%F{$color11}$(alien_git_stash)$(alien_git_lr) %f%k%K{$color12}%F{$color10}%f%k%K{$color12}%F{$color13}$(alien_git_dirty) %f%k%F{$color12}%f
-%F{$color3}$(alien_ssh_client)%f%F{$color14}`alien_venv`%f%F{$color8}%B❱%b%f "
+    alien_prompt_append_section "$(alien_git_branch)" $color9 $color7 $ALIEN_SECTION_SEP_SYM
+    alien_prompt_append_section "$(alien_git_stash)$(alien_git_lr) " $color10 $color12 $ALIEN_SECTION_SEP_SYM
+    alien_prompt_append_section "$(alien_git_dirty) " $color13 $color12 $ALIEN_SECTION_SEP_SYM
   elif [[ $(alien_is_hg) == 1 ]]; then
-    PROMPT="
-%(?.%K{$color0}%F{$color1}%f%k.%K{$color0}%F{$color1r}%f%k)%K{$color0}%F{$color2} $(alien_date_time_info)$(alien_battery_stat) %f%k%K{$color3}%F{$color0}%f%k%K{$color3}%F{$color4} $_user %f%k%K{$color5}%F{$color3}%f%k%K{$color5}%F{$color6} %1~ %f%k%F{$color5}%K{$color7}%k%f%K{$color7}%F{$color9}`alien_hg_branch`%f%k%K{$color10}%F{$color7}%f%k%K{$color10}%F{$color11} %f%k%K{$color12}%F{$color10}%f%k%K{$color12}%F{$color13} %f%k%F{$color12}%f
-%F{$color3}$(alien_ssh_client)%f%F{$color14}`alien_venv`%f%F{$color8}%B❱%b%f "
+    alien_prompt_append_section "$(alien_hg_branch)" $color7 $color10 $ALIEN_SECTION_SEP_SYM
   elif [[ $(alien_is_svn) == 1 ]]; then
-    PROMPT="
-%(?.%K{$color0}%F{$color1}%f%k.%K{$color0}%F{$color1r}%f%k)%K{$color0}%F{$color2} $(alien_date_time_info)$(alien_battery_stat) %f%k%K{$color3}%F{$color0}%f%k%K{$color3}%F{$color4} $_user %f%k%K{$color5}%F{$color3}%f%k%K{$color5}%F{$color6} %1~ %f%k%F{$color5}%K{$color7}%k%f%K{$color7}%F{$color9}`alien_svn_branch`%f%k%K{$color10}%F{$color7}%f%k%K{$color10}%F{$color11} %f%k%K{$color12}%F{$color10}%f%k%K{$color12}%F{$color13} %f%k%F{$color12}%f
-%F{$color3}$(alien_ssh_client)%f%F{$color14}`alien_venv`%f%F{$color8}%B❱%b%f "
-  else
-    PROMPT="
-%(?.%K{$color0}%F{$color1}%f%k.%K{$color0}%F{$color1r}%f%k)%K{$color0}%F{$color2} $(alien_date_time_info)$(alien_battery_stat) %f%k%K{$color3}%F{$color0}%f%k%K{$color3}%F{$color4} $_user %f%k%K{$color5}%F{$color3}%f%k%K{$color5}%F{$color6} %1~ %f%k%F{$color5}%f
-%F{$color3}$(alien_ssh_client)%f%F{$color14}`alien_venv`%f%F{$color8}%B❱%b%f "
+    alien_prompt_append_section "$(alien_svn_branch)" $color7 $color10 $ALIEN_SECTION_SEP_SYM
   fi
+  alien_prompt_end
+  PROMPT=$(alien_prompt_render)
   zle && zle reset-prompt
   async_stop_worker lprompt -n
 }

--- a/modules/init.zsh
+++ b/modules/init.zsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env zsh
 
+[[ -z "${ALIEN_SECTION_SEP_SYM}" ]] && ALIEN_SECTION_SEP_SYM=
+[[ -z "${ALIEN_PROMPT_SYM}" ]] && ALIEN_PROMPT_SYM=❱
 [[ -z "${ALIEN_GIT_STASH_SYM}" ]] && ALIEN_GIT_STASH_SYM='@'
 
 if [[ ${USE_NERD_FONT} = 1 ]]; then

--- a/modules/prompt.zsh
+++ b/modules/prompt.zsh
@@ -1,0 +1,89 @@
+#!/usr/bin/env zsh
+
+ALIEN_PROMPT_SECTIONS=()
+
+alien_colorized() {
+  local __content="$1"
+  local __fg="$2"
+  local __bg="$3"
+  [[ -n "$__fg" ]] && echo -en "%F{$__fg}"
+  [[ -n "$__bg" ]] && echo -en "%K{$__bg}"
+  echo -en "${__content}"
+  [[ -n "$__bg" ]] && echo -en "%k"
+  [[ -n "$__fg" ]] && echo -en "%f"
+}
+
+alien_prompt_append_section() {
+  local __content=$1
+  local __fg=$2
+  local __bg=$3
+  local __sep=$4
+  ALIEN_PROMPT_SECTIONS+=("$__content","$__fg","$__bg","$__sep")
+}
+
+alien_prompt_prepend_section() {
+  local __content=$1
+  local __fg=$2
+  local __bg=$3
+  local __sep=$4
+  ALIEN_PROMPT_SECTIONS=("$__content","$__fg","$__bg","$__sep" ${ALIEN_PROMPT_SECTIONS[@]})
+}
+
+alien_prompt_render() {
+  local __last_bg=
+  local __last_sep=
+  for section in $ALIEN_PROMPT_SECTIONS; do
+    # set read-delimiter to \0 and add it to $section in order to allow \n in content
+    IFS=',' read -d"\0" __content __fg __bg __sep <<< "${section}\0"
+    [[ -n "$__last_sep" ]] && alien_colorized "$__last_sep" "$__last_bg" "$__bg"
+    __last_bg="$__bg"
+    __last_sep="$__sep"
+    alien_colorized "$__content" "$__fg" "$__bg"
+  done
+}
+
+alien_prompt_start() {
+  ALIEN_PROMPT_SECTIONS=()
+  # date/time section
+  if [[ $ALIEN_SHOW_DATE_TIME != 0 ]]; then
+    alien_prompt_append_section " $(alien_date_time_info) " $color2 $color0 $ALIEN_SECTION_SEP_SYM
+  fi
+  # battery section
+  if [[ $ALIEN_SHOW_BATTERY != 0 ]]; then
+    alien_prompt_append_section " $(alien_battery_stat) " $color2 $color0 $ALIEN_SECTION_SEP_SYM
+  fi
+  # user/host section
+  if [[ $ALIEN_SHOW_USER_HOST != 0 ]]; then
+    alien_prompt_append_section " $(alien_user_host_info) " $color4 $color3 $ALIEN_SECTION_SEP_SYM
+  fi
+  # path section
+  if [[ $ALIEN_LONG_PATH != 0 ]]; then
+    alien_prompt_append_section " %~ " $color6 $color5 $ALIEN_SECTION_SEP_SYM
+  else
+    alien_prompt_append_section " %1~ " $color6 $color5 $ALIEN_SECTION_SEP_SYM
+  fi
+  # determine background-color of first section
+  IFS=',' read -d"\0" __content __fg __bg __sep <<< "${ALIEN_PROMPT_SECTIONS[1]}\0"
+  # prepend exit-code section
+  local __exit_code_info="%(?"
+  __exit_code_info+=".$(alien_colorized $ALIEN_SECTION_SEP_SYM $color1 $__bg)"
+  if [[ $ALIEN_SHOW_EXIT_CODE != 0 ]]; then
+    __exit_code_info+=".$(alien_colorized "%?" $color2 $color1r)"
+    __exit_code_info+="$(alien_colorized "$ALIEN_SECTION_SEP_SYM" $color1r $__bg)"
+  else
+    __exit_code_info+=".$(alien_colorized "$ALIEN_SECTION_SEP_SYM" $color1r $__bg)"
+  fi
+  __exit_code_info+=")"
+  alien_prompt_prepend_section $__exit_code_info
+}
+
+alien_prompt_end() {
+  # newline
+  alien_prompt_append_section $'\n'
+  # ssh-client section
+  alien_prompt_append_section "$(alien_ssh_client)" $color3
+  # venv section
+  alien_prompt_append_section "$(alien_venv)" $color14
+  # prompt
+  alien_prompt_append_section "%B${ALIEN_PROMPT_SYM}%b " $color8
+}

--- a/modules/system.zsh
+++ b/modules/system.zsh
@@ -1,5 +1,16 @@
 #!/usr/bin/env zsh
 
+alien_user_host_info(){
+  if [[ "${DEFAULT_USER}" == "${USER}" ]]; then
+    __user=''
+  else
+    [[ -n "$SUDO_USER" && "$SUDO_USER" != "${_user}" ]] && __user="$USER($SUDO_USER)" || __user="$USER"
+  fi
+  if [[ ${ALIEN_SHOW_HOST} != 0 ]]; then
+    __user+="@%M"
+  fi
+  echo -n "${__user}"
+}
 
 alien_storage_info(){
   __df=$(df -h . | tail -1)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [x] Docs have been added / updated in README.md (for features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - make the code taking care of composition of the prompt more clear
  - make it more configurable


* **What is the new behavior (if this is a feature change)?**
New configuration options:
  - `ALIEN_SHOW_EXIT_CODE` - show the numeric exit-code
  - `ALIEN_SHOW_DATE_TIME` - completely disable the date/time-section
  - `ALIEN_SHOW_BATTERY` - completely disable the battery-section
  - `ALIEN_SHOW_USER_HOST` - completely disable the user/host-section
  - `ALIEN_SHOW_HOST` - show  the hostname
  - `ALIEN_LONG_PATH` - show the full path
  - `ALIEN_PROMPT_SYM` - change the symbol of the prompt
  - `ALIEN_SECTION_SEP_SYM` - change the symbol of the separator between sections

* **Does this PR introduce a breaking change?** (What changes might users need to make in their configuration due to this PR?)
  - every new option is enabled by default


* **Other information**:
![alien-refactor-configurable](https://user-images.githubusercontent.com/7346933/53294219-bdebe200-37e2-11e9-8811-526fefaebf93.png)


