### PR TITLE
fix user cd collision

### DIFF
--- a/modules/async.zsh
+++ b/modules/async.zsh
@@ -9,7 +9,7 @@ function alien_left_prompt_update_completed(){
 }
 
 function alien_left_prompt_update() {
-  cd "${1}" || return
+  builtin cd "${1}" || return
   VIRTUAL_ENV=$2
   SSH_CLIENT=$3
   echo -n "$(alien_prompt_render_left 'async')"
@@ -30,7 +30,7 @@ function alien_right_prompt_update_completed(){
 }
 
 function alien_right_prompt_update() {
-  cd "${1}" || return
+  builtin cd "${1}" || return
   VIRTUAL_ENV=$2
   SSH_CLIENT=$3
   echo -n "$(alien_prompt_render_right 'async')"


### PR DESCRIPTION
Some users have their own custom cd script

```zsh
cd() {
  builtin cd $1 && ls
}
```

and because alien uses normal cd, it produces unexpected behaviors:

https://user-images.githubusercontent.com/12099108/174499595-e0733c0f-a793-427b-b234-67a2b747a54b.mov

this pr prevent this from happening by using `builtin cd` instead
