### PR TITLE
updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add the following line to your `.zshrc` depending on your zsh plugin manager
 ```bash
 git clone https://github.com/eendroroy/alien.git
 cd alien
-git submodule update --init --recursive
+git submodule update --init --recursive --remote
 ```
 
 Add the following line to your `~/.zshrc`


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Documentation Update



* **What is the current behavior?**
During a fresh installation of Alien (Manually Cloning) i noticed the following message before my prompt loads: 
`egrep: warning: egrep is obsolescent; using grep -E`
Investigation lead me to the submodule zsh-256color at an old commit, running the `git submodule update --init --recursive --remote` fixed this issue.
This PR updates the readme to include `--remote` when following the instructions for Manually Cloning

* **What is the new behavior (if this is a feature change)?**
New users / installations will avoid the above issue

